### PR TITLE
get-twilio-resource-sid action improvements

### DIFF
--- a/docs/usage/composite-actions-general.md
+++ b/docs/usage/composite-actions-general.md
@@ -51,7 +51,7 @@ https://`TWILIO_AREA`.twilio.com/`VERSION`/`API_TYPE`
 
 (Taskrouter is an exception, as the Workspace sid is automatically included)
 
-From the JSON response, the `JSON_TYPE` key is used to read the array of resources. A search is made in this array for an object with the property `SEARCH_BY` == `SEARCH_VALUE`.
+From the JSON response, `.meta.key` is used to read the array of resources. A search is made in this array for an object with the property `SEARCH_BY` == `SEARCH_VALUE`.
 
 **Outputs**:
 
@@ -69,7 +69,6 @@ steps:
     with:
       TWILIO_AREA: sync
       API_TYPE: Services
-      JSON_TYPE: services
       SEARCH_BY: unique_name
       SEARCH_VALUE: default
       TWILIO_API_KEY: ${{ env.TWILIO_API_KEY }}
@@ -112,7 +111,6 @@ steps:
     with:
       TWILIO_AREA: taskrouter
       API_TYPE: TaskChannels
-      JSON_TYPE: channels
       SEARCH_BY: unique_name
       SEARCH_VALUE: voice
       TWILIO_API_KEY: ${{ env.TWILIO_API_KEY }}
@@ -134,7 +132,6 @@ steps:
     with:
       TWILIO_AREA: conversations
       API_TYPE: Services
-      JSON_TYPE: services
       SEARCH_BY: friendly_name
       SEARCH_VALUE: "Flex Conversation Service"
       TWILIO_API_KEY: ${{ env.TWILIO_API_KEY }}

--- a/get-twilio-resource-sid/action.yaml
+++ b/get-twilio-resource-sid/action.yaml
@@ -1,21 +1,18 @@
 name: "Get Twilio Resource SID"
-description: Fetch the SID of an existing Twilio resource from a Twilio account
+description: Fetch the SID of an existing Twilio resource from a Twilio account. [Documentation](https://github.com/zingdevlimited/actions-helpers/blob/v3/docs/usage/composite-actions-general.md#get-twilio-resource-sid)
 inputs:
   TWILIO_AREA:
     required: true
-    description: "The API subdomain. e.g.: sync, studio, taskrouter"
+    description: "The API subdomain. e.g.: `sync`, `studio`, `taskrouter`"
   API_TYPE:
     required: true
-    description: "The type of resource in the format used in the API call URL path. e.g.: Services, Flows, TaskQueues"
-  JSON_TYPE:
-    required: true
-    description: "The name of the array field on the response of a List API call. e.g.: services, flows, task_queues"
+    description: "The type of resource in the format used in the API call URL path. e.g.: `Services`, `Flows`, `TaskQueues`"
   SEARCH_BY:
     required: true
-    description: "The name of the field on a resource object that you want to match in search. e.g.: friendly_name, unique_name"
+    description: "The name of the field on a resource object that you want to match in search. e.g.: `friendly_name`, `unique_name`"
   SEARCH_VALUE:
     required: true
-    description: "Used to select your resource by ensuring resource.<SEARCH_BY> == <SEARCH_VALUE>"
+    description: "Used to select your resource by ensuring `resource.<SEARCH_BY> == <SEARCH_VALUE>`"
   VERSION:
     required: false
     default: v1
@@ -26,9 +23,16 @@ inputs:
   TWILIO_API_SECRET:
     required: true
     description: Twilio API Secret
-  NO_ERROR_ON_NO_RESULTS:
+  ALLOW_NO_RESULTS:
     required: false
-    description: "Default 0. Set to 1 if you don't want an exit code 1 when the resource can't be found."
+    description: |
+      (Optional) set to `true` to not throw an error if the resource could not be found.
+
+      Instead, the `SID` output will return an empty string.
+  # Obsolete Inputs
+  JSON_TYPE:
+    required: false
+    description: (OBSOLETE) No longer has an effect
 outputs:
   SID:
     description: The resulting SID
@@ -45,7 +49,6 @@ runs:
         [[ -z "${{ inputs.API_TYPE }}" ]] && echo "::error::Missing API_TYPE in inputs" && fail=1
 
         if [ "${{ inputs.TWILIO_AREA }}" != "taskrouter" ] || [ "${{ inputs.API_TYPE }}" != "Workspaces" ]; then
-          [[ -z "${{ inputs.JSON_TYPE }}" ]] && echo "::error::Missing JSON_TYPE in inputs" && fail=1
           [[ -z "${{ inputs.SEARCH_BY }}" ]] && echo "::error::Missing SEARCH_BY in inputs" && fail=1
           [[ -z "${{ inputs.SEARCH_VALUE }}" ]] && echo "::error::Missing SEARCH_VALUE in inputs" && fail=1
         fi
@@ -62,11 +65,10 @@ runs:
         result=$(${{ github.action_path }}/get-twilio-resource-sid.sh \
           "${{ inputs.TWILIO_AREA }}" \
           "${{ inputs.API_TYPE }}" \
-          "${{ inputs.JSON_TYPE }}" \
           "${{ inputs.SEARCH_BY }}" \
           "${{ inputs.SEARCH_VALUE }}" \
           "${{ inputs.VERSION }}" \
-          "${{ inputs.NO_ERROR_ON_NO_RESULTS }}")
+          "${{ inputs.ALLOW_NO_RESULTS }}")
         echo "SID=$result" >> "$GITHUB_OUTPUT"
       env:
         TWILIO_API_KEY: ${{ inputs.TWILIO_API_KEY }}

--- a/get-twilio-resource-sid/action.yaml
+++ b/get-twilio-resource-sid/action.yaml
@@ -26,6 +26,9 @@ inputs:
   TWILIO_API_SECRET:
     required: true
     description: Twilio API Secret
+  ERROR_ON_MISSING:
+    required: false
+    description: "Default true. Set to false if you don't want an exit code 1 when the resource can't be found."
 outputs:
   SID:
     description: The resulting SID
@@ -62,7 +65,8 @@ runs:
           "${{ inputs.JSON_TYPE }}" \
           "${{ inputs.SEARCH_BY }}" \
           "${{ inputs.SEARCH_VALUE }}" \
-          "${{ inputs.VERSION }}")
+          "${{ inputs.VERSION }}" \
+          "${{ inputs.ERROR_ON_MISSING }}")
         echo "SID=$result" >> "$GITHUB_OUTPUT"
       env:
         TWILIO_API_KEY: ${{ inputs.TWILIO_API_KEY }}

--- a/get-twilio-resource-sid/action.yaml
+++ b/get-twilio-resource-sid/action.yaml
@@ -26,9 +26,9 @@ inputs:
   TWILIO_API_SECRET:
     required: true
     description: Twilio API Secret
-  ERROR_ON_MISSING:
+  NO_ERROR_ON_NO_RESULTS:
     required: false
-    description: "Default true. Set to false if you don't want an exit code 1 when the resource can't be found."
+    description: "Default 0. Set to 1 if you don't want an exit code 1 when the resource can't be found."
 outputs:
   SID:
     description: The resulting SID
@@ -66,7 +66,7 @@ runs:
           "${{ inputs.SEARCH_BY }}" \
           "${{ inputs.SEARCH_VALUE }}" \
           "${{ inputs.VERSION }}" \
-          "${{ inputs.ERROR_ON_MISSING }}")
+          "${{ inputs.NO_ERROR_ON_NO_RESULTS }}")
         echo "SID=$result" >> "$GITHUB_OUTPUT"
       env:
         TWILIO_API_KEY: ${{ inputs.TWILIO_API_KEY }}

--- a/get-twilio-resource-sid/get-twilio-resource-sid.sh
+++ b/get-twilio-resource-sid/get-twilio-resource-sid.sh
@@ -32,7 +32,7 @@ function listAndFindResource {
   searchBy=$4
   searchValue=$5
   [[ -z $6 ]] && version="v1" || version=$6
-  [[ -z $7 ]] && noErrorOnZeroResults=1 || noErrorOnZeroResults=0
+  [[ -z $7 ]] && noErrorOnZeroResults=0 || noErrorOnZeroResults=1
 
   local resourceListResponse resources resourceSearch resultCount
 
@@ -100,7 +100,7 @@ function listAndFindTaskrouterResource {
   jsonType=$2
   searchBy=$3
   searchValue=$4
-  [[ -z $5 ]] && noErrorOnZeroResults=1 || noErrorOnZeroResults=0
+  [[ -z $5 ]] && noErrorOnZeroResults=0 || noErrorOnZeroResults=1
 
   local workspaceSid
 

--- a/get-twilio-resource-sid/get-twilio-resource-sid.sh
+++ b/get-twilio-resource-sid/get-twilio-resource-sid.sh
@@ -100,7 +100,7 @@ function listAndFindTaskrouterResource {
   jsonType=$2
   searchBy=$3
   searchValue=$4
-  [[ -z $5 ]] && noErrorOnZeroResults=0 || noErrorOnZeroResults=1
+  [[ -z $5 ]] && noErrorOnZeroResults=1 || noErrorOnZeroResults=0
 
   local workspaceSid
 

--- a/get-twilio-resource-sid/get-twilio-resource-sid.sh
+++ b/get-twilio-resource-sid/get-twilio-resource-sid.sh
@@ -169,9 +169,9 @@ allowNoResults=$6
 
 
 if [[ "$twilioArea" == "taskrouter" ]]; then
-  response=$(listAndFindTaskrouterResource "$apiType" "$searchBy" "$searchValue", "$allowNoResults") || exit 1
+  response=$(listAndFindTaskrouterResource "$apiType" "$searchBy" "$searchValue" "$allowNoResults") || exit 1
 else
-  response=$(listAndFindResource "$twilioArea" "$apiType" "$searchBy" "$searchValue" "$version", "$allowNoResults") || exit 1
+  response=$(listAndFindResource "$twilioArea" "$apiType" "$searchBy" "$searchValue" "$version" "$allowNoResults") || exit 1
 fi
 
 echo "$response" | jq -r .sid

--- a/get-twilio-resource-sid/get-twilio-resource-sid.sh
+++ b/get-twilio-resource-sid/get-twilio-resource-sid.sh
@@ -24,7 +24,7 @@ function checkEnv {
 ### SOURCE scripts/src/lib/twilio/generic.sh ###
 
 function listAndFindResource {
-  local twilioArea apiType jsonType searchBy searchValue version errorOnMissing
+  local twilioArea apiType jsonType searchBy searchValue version noErrorOnZeroResults
 
   twilioArea=$1
   apiType=$2
@@ -32,7 +32,7 @@ function listAndFindResource {
   searchBy=$4
   searchValue=$5
   [[ -z $6 ]] && version="v1" || version=$6
-  [[ -z $7 ]] && errorOnMissing=$7 || errorOnMissing=true
+  [[ -z $7 ]] && noErrorOnZeroResults=1 || noErrorOnZeroResults=0
 
   local resourceListResponse resources resourceSearch resultCount
 
@@ -55,7 +55,7 @@ function listAndFindResource {
   )
   resultCount=$(echo "$resourceSearch" | jq 'length')
 
-  if ((resultCount == 0 && errorOnMissing)); then
+  if ((resultCount == 0 && noErrorOnZeroResults == 0)); then
     echo "::error::$twilioArea $jsonType with $searchBy '$searchValue' does not exist." >&2
     exit 1
   fi
@@ -94,13 +94,13 @@ function getWorkspaceSid {
 }
 
 function listAndFindTaskrouterResource {
-  local apiType jsonType searchBy searchValue errorOnMissing
+  local apiType jsonType searchBy searchValue noErrorOnZeroResults
 
   apiType=$1
   jsonType=$2
   searchBy=$3
   searchValue=$4
-  [[ -z $5 ]] && errorOnMissing=$5 || errorOnMissing=true
+  [[ -z $5 ]] && noErrorOnZeroResults=0 || noErrorOnZeroResults=1
 
   local workspaceSid
 
@@ -129,7 +129,7 @@ function listAndFindTaskrouterResource {
     )
     resultCount=$(echo "$resourceSearch" | jq 'length')
 
-    if ((resultCount == 0 && errorOnMissing)); then
+    if ((resultCount == 0 && noErrorOnZeroResults == 0)); then
       echo "::error::$apiType with $searchBy '$searchValue' does not exist." >&2
       exit 1
     fi
@@ -206,13 +206,13 @@ jsonType=$3
 searchBy=$4
 searchValue=$5
 version=$6
-errorOnMissing=$7
+noErrorOnZeroResults=$7
 
 
 if [[ "$twilioArea" == "taskrouter" ]]; then
-  response=$(listAndFindTaskrouterResource "$apiType" "$jsonType" "$searchBy" "$searchValue", "$errorOnMissing") || exit 1
+  response=$(listAndFindTaskrouterResource "$apiType" "$jsonType" "$searchBy" "$searchValue", "$noErrorOnZeroResults") || exit 1
 else
-  response=$(listAndFindResource "$twilioArea" "$apiType" "$jsonType" "$searchBy" "$searchValue" "$version", "$errorOnMissing") || exit 1
+  response=$(listAndFindResource "$twilioArea" "$apiType" "$jsonType" "$searchBy" "$searchValue" "$version", "$noErrorOnZeroResults") || exit 1
 fi
 
 echo "$response" | jq -r .sid

--- a/get-twilio-resource-sid/get-twilio-resource-sid.sh
+++ b/get-twilio-resource-sid/get-twilio-resource-sid.sh
@@ -24,28 +24,29 @@ function checkEnv {
 ### SOURCE scripts/src/lib/twilio/generic.sh ###
 
 function listAndFindResource {
-  local twilioArea apiType jsonType searchBy searchValue version noErrorOnZeroResults
+  local twilioArea apiType searchBy searchValue version allowNoResults
 
   twilioArea=$1
   apiType=$2
-  jsonType=$3
-  searchBy=$4
-  searchValue=$5
-  [[ -z $6 ]] && version="v1" || version=$6
-  [[ -z $7 ]] && noErrorOnZeroResults=0 || noErrorOnZeroResults=1
+  searchBy=$3
+  searchValue=$4
+  [[ -z $5 ]] && version="v1" || version=$5
+  [[ "$6" == "true" ]] && allowNoResults="true"
 
-  local resourceListResponse resources resourceSearch resultCount
+  local resourceListResponse keyName resources resourceSearch resultCount
 
   resourceListResponse=$(curl -sX GET "https://$twilioArea.twilio.com/$version/$apiType" \
     -u "$TWILIO_API_KEY":"$TWILIO_API_SECRET")
 
-  resources=$(echo "$resourceListResponse" | jq -r --arg TYPE "$jsonType" '.[$TYPE] // empty')
+  keyName=$(echo "$resourceListResponse" | jq -r '.meta.key // empty')
 
-  if [ -z "$resources" ]; then
-    echo "::error::Failed to list $twilioArea $jsonType. Response:" >&2
+  if [ -z "$keyName" ]; then
+    echo "::error::Failed to list $twilioArea $apiType. Response:" >&2
     echo "::error::$resourceListResponse" >&2
     exit 1
   fi
+
+  resources=$(echo "$resourceListResponse" | jq -r --arg TYPE "$keyName" '.[$TYPE] // empty')
 
   resourceSearch=$(
     echo "$resources" | jq \
@@ -55,12 +56,17 @@ function listAndFindResource {
   )
   resultCount=$(echo "$resourceSearch" | jq 'length')
 
-  if ((resultCount == 0 && noErrorOnZeroResults == 0)); then
-    echo "::error::$twilioArea $jsonType with $searchBy '$searchValue' does not exist." >&2
+  if ((resultCount == 0)); then
+    if [ -n "$allowNoResults" ]; then
+      echo "$twilioArea $apiType with $searchBy '$searchValue' does not exist. Returning empty sid" >&2
+      echo ""
+      exit 0
+    fi
+    echo "::error::$twilioArea $apiType with $searchBy '$searchValue' does not exist." >&2
     exit 1
   fi
   if ((resultCount > 1)); then
-    echo "::error::Searching for $twilioArea $jsonType with $searchBy '$searchValue' returned $resultCount results." >&2
+    echo "::error::Searching for $twilioArea $apiType with $searchBy '$searchValue' returned $resultCount results." >&2
     exit 1
   fi
 
@@ -94,32 +100,32 @@ function getWorkspaceSid {
 }
 
 function listAndFindTaskrouterResource {
-  local apiType jsonType searchBy searchValue noErrorOnZeroResults
+  local apiType searchBy searchValue allowNoResults
 
   apiType=$1
-  jsonType=$2
-  searchBy=$3
-  searchValue=$4
-  [[ -z $5 ]] && noErrorOnZeroResults=0 || noErrorOnZeroResults=1
-
-  local workspaceSid
-
-  workspaceSid=$(getWorkspaceSid) || exit 1
+  searchBy=$2
+  searchValue=$3
+  [[ "$4" == "true" ]] && allowNoResults="true"
+  
   if [ "$apiType" == "Workspaces" ]; then
     getWorkspace || exit 1
   else
-    local resourceListResponse resources resourceSearch resultCount
+    local workspaceSid keyName resourceListResponse resources resourceSearch resultCount
+
+    workspaceSid=$(getWorkspaceSid) || exit 1
 
     resourceListResponse=$(curl -sX GET "https://taskrouter.twilio.com/v1/Workspaces/$workspaceSid/$apiType" \
       -u "$TWILIO_API_KEY":"$TWILIO_API_SECRET")
 
-    resources=$(echo "$resourceListResponse" | jq -r --arg TYPE "$jsonType" '.[$TYPE] // empty')
+    keyName=$(echo "$resourceListResponse" | jq -r '.meta.key // empty')
 
-    if [ -z "$resources" ]; then
-      echo "::error::Failed to list $apiType. Response:" >&2
+    if [ -z "$keyName" ]; then
+      echo "::error::Failed to list Taskrouter $apiType. Response:" >&2
       echo "::error::$resourceListResponse" >&2
       exit 1
     fi
+
+    resources=$(echo "$resourceListResponse" | jq -r --arg TYPE "$keyName" '.[$TYPE] // empty')
 
     resourceSearch=$(
       echo "$resources" | jq \
@@ -129,8 +135,13 @@ function listAndFindTaskrouterResource {
     )
     resultCount=$(echo "$resourceSearch" | jq 'length')
 
-    if ((resultCount == 0 && noErrorOnZeroResults == 0)); then
-      echo "::error::$apiType with $searchBy '$searchValue' does not exist." >&2
+    if ((resultCount == 0)); then
+      if [ -n "$allowNoResults" ]; then
+        echo "Taskrouter $apiType with $searchBy '$searchValue' does not exist. Returning empty sid" >&2
+        echo ""
+        exit 0
+      fi
+      echo "::error::Taskrouter $apiType with $searchBy '$searchValue' does not exist." >&2
       exit 1
     fi
     if ((resultCount > 1)); then
@@ -142,57 +153,6 @@ function listAndFindTaskrouterResource {
   fi
 }
 
-function getWorkflowsMap {
-  local workspaceSid
-
-  workspaceSid=$1
-  if [ -z "$workspaceSid" ]; then
-    workspaceSid="$(getWorkspaceSid)"
-  fi
-
-  local workflowListResponse workflows workflowMap
-
-  workflowListResponse=$(curl -sX GET "https://taskrouter.twilio.com/v1/Workspaces/$workspaceSid/Workflows" \
-    -u "$TWILIO_API_KEY":"$TWILIO_API_SECRET")
-
-  workflows="$(echo "$workflowListResponse" | jq '.workflows // empty')"
-
-  if [ -z "$workflows" ]; then
-    echo "::error::Failed to list Workflows. Response:" >&2
-    echo "::error::$workflowListResponse" >&2
-    exit 1
-  fi
-
-  workflowMap=$(echo "$workflows" | jq 'map({ (.friendly_name): .sid }) | add')
-  echo "$workflowMap"
-}
-
-function getTaskChannelMap {
-  local workspaceSid
-
-  workspaceSid=$1
-  if [ -z "$workspaceSid" ]; then
-    workspaceSid="$(getWorkspaceSid)"
-  fi
-
-  local taskChannelListResponse channels taskChannelMap
-
-  taskChannelListResponse=$(curl -sX GET "https://taskrouter.twilio.com/v1/Workspaces/$workspaceSid/TaskChannels" \
-    -u "$TWILIO_API_KEY":"$TWILIO_API_SECRET")
-
-  channels="$(echo "$taskChannelListResponse" | jq '.channels // empty')"
-
-  if [ -z "$channels" ]; then
-    echo "::error::Failed to list Task Channels. Response:" >&2
-    echo "::error::$taskChannelListResponse" >&2
-    exit 1
-  fi
-
-  taskChannelMap=$(echo "$channels" | jq 'map({ (.unique_name): .sid }) | add')
-
-  echo "$taskChannelMap"
-}
-
 ### SOURCE scripts/src/get-twilio-resource-sid.sh ###
 # Version 1.0.0
 
@@ -202,18 +162,16 @@ checkEnv "TWILIO_API_KEY TWILIO_API_SECRET" || exit 1
 
 twilioArea=$1
 apiType=$2
-jsonType=$3
-searchBy=$4
-searchValue=$5
-version=$6
-noErrorOnZeroResults=$7
+searchBy=$3
+searchValue=$4
+version=$5
+allowNoResults=$6
 
 
 if [[ "$twilioArea" == "taskrouter" ]]; then
-  response=$(listAndFindTaskrouterResource "$apiType" "$jsonType" "$searchBy" "$searchValue", "$noErrorOnZeroResults") || exit 1
+  response=$(listAndFindTaskrouterResource "$apiType" "$searchBy" "$searchValue", "$allowNoResults") || exit 1
 else
-  response=$(listAndFindResource "$twilioArea" "$apiType" "$jsonType" "$searchBy" "$searchValue" "$version", "$noErrorOnZeroResults") || exit 1
+  response=$(listAndFindResource "$twilioArea" "$apiType" "$searchBy" "$searchValue" "$version", "$allowNoResults") || exit 1
 fi
 
 echo "$response" | jq -r .sid
-

--- a/get-twilio-resource-sid/get-twilio-resource-sid.sh
+++ b/get-twilio-resource-sid/get-twilio-resource-sid.sh
@@ -32,6 +32,8 @@ function listAndFindResource {
   searchValue=$4
   [[ -z $5 ]] && version="v1" || version=$5
   [[ "$6" == "true" ]] && allowNoResults="true"
+  
+  [[ -z $5 ]] && [[ $twilioArea == "studio" ]] && version="v2" # Studio should use v2
 
   local resourceListResponse keyName resources resourceSearch resultCount
 


### PR DESCRIPTION
## Get Twilio Resource Sid Action

- Added new input ALLOW_NO_RESULTS that can be set to true to not error if a resource is missing
- Removed JSON_TYPE input requirement by deducing the correct field with `.meta.key` on the List response
- Make studio use v2 API by default
- Clean up unused areas of shell script
