### PR TITLE
feat: Prevent lookup if no taskrouter is required

### DIFF
--- a/.schemas/update-studio-flows.json
+++ b/.schemas/update-studio-flows.json
@@ -85,7 +85,7 @@
     },
     "workflowMap": {
       "type": "object",
-      "description": "(Optional) Identifier (send-to-flex.attributes.workflowName) to Taskrouter Workflow sid map. If omitted, will not perform lookup/replacement.",
+      "description": "(Optional) Identifier (send-to-flex.attributes.workflowName) to Taskrouter Workflow sid map. If omitted, Friendly Name will be used as the identifier.",
       "patternProperties": {
         "^.*$": {
           "type": "string"

--- a/.schemas/update-studio-flows.json
+++ b/.schemas/update-studio-flows.json
@@ -33,7 +33,10 @@
             "description": "(Optional) Set to true to create the Studio Flow resource if it does not already exist"
           }
         },
-        "required": ["name", "path"],
+        "required": [
+          "name",
+          "path"
+        ],
         "additionalProperties": false
       },
       "description": "The list of Studio Flows to deploy"
@@ -72,14 +75,17 @@
             "description": "The URL environment suffix. Set to null for production"
           }
         },
-        "required": ["name", "environmentSuffix"],
+        "required": [
+          "name",
+          "environmentSuffix"
+        ],
         "additionalProperties": false
       },
       "description": "The list of function service instances that are referred to by the studio flows"
     },
     "workflowMap": {
       "type": "object",
-      "description": "(Optional) Identifier (send-to-flex.attributes.workflowName) to Taskrouter Workflow sid map. If omitted, Friendly Name will be used as the identifier.",
+      "description": "(Optional) Identifier (send-to-flex.attributes.workflowName) to Taskrouter Workflow sid map. If omitted, will not perform lookup/replacement.",
       "patternProperties": {
         "^.*$": {
           "type": "string"
@@ -109,6 +115,9 @@
       "description": "Set to true to evaluate any $VARIABLE_NAME references in the configuration file with envsubst"
     }
   },
-  "required": ["flows", "replaceWidgetTypes"],
+  "required": [
+    "flows",
+    "replaceWidgetTypes"
+  ],
   "additionalProperties": false
 }

--- a/update-studio-flows/update-studio-flows.sh
+++ b/update-studio-flows/update-studio-flows.sh
@@ -876,8 +876,8 @@ if [ -n "$(echo "$config" | jq '.functionServices // empty')" ]; then
   done
 fi
 
-workspaceSid=$(getWorkspaceSid)
-if [ -n "$workspaceSid" ] && [ ! "$workspaceSid" == "null" ]; then
+if [ "$(usesWidgetType "send-to-flex")" ]; then
+  workspaceSid=$(getWorkspaceSid)
   workflows=$(echo "$config" | jq '.workflowMap // empty')
   if [ -z "$workflows" ]; then
     # Get workflow map based on friendly name

--- a/update-studio-flows/update-studio-flows.sh
+++ b/update-studio-flows/update-studio-flows.sh
@@ -877,13 +877,14 @@ if [ -n "$(echo "$config" | jq '.functionServices // empty')" ]; then
 fi
 
 workspaceSid=$(getWorkspaceSid)
-
-workflows=$(echo "$config" | jq '.workflowMap // empty')
-if [ -z "$workflows" ]; then
-  # Get workflow map based on friendly name
-  workflows=$(getWorkflowsMap "$workspaceSid")
+if [ -n "$workspaceSid" ] && [ ! "$workspaceSid" == "null" ]; then
+  workflows=$(echo "$config" | jq '.workflowMap // empty')
+  if [ -z "$workflows" ]; then
+    # Get workflow map based on friendly name
+    workflows=$(getWorkflowsMap "$workspaceSid")
+  fi
+  channels=$(getTaskChannelMap "$workspaceSid")
 fi
-channels=$(getTaskChannelMap "$workspaceSid")
 
 variables=$(echo "$config" | jq '.variableReplacements')
 


### PR DESCRIPTION
Preventing the lookup of taskrouter if no workspace SID is found rather than erroring, current behaviour affects use of this action in projects where taskrouter is not configured (e.g. pure studio, routing to external systems etc.) so this looks to address that, these changes previously made for ETEL project.