### PR TITLE
Improve Build Flex Plugin Workflow + Update Flex Skills action

### DIFF
--- a/.github/workflows/build-twilio-flex-plugin.yaml
+++ b/.github/workflows/build-twilio-flex-plugin.yaml
@@ -110,7 +110,7 @@ jobs:
           cache-dependency-path: ${{ env.CACHE_DEPENDENCY_PATH }}
 
       - name: Setup Flex CLI
-        if: ${{ inputs.SKIP_CLI_INSTALL != true }}
+        if: inputs.SKIP_CLI_INSTALL != true
         uses: ./helpers/setup-flex-cli
         with:
           PLUGIN_DIRECTORY: main/${{ env.PLUGIN_DIR }}
@@ -127,6 +127,24 @@ jobs:
       - name: Install Dependencies
         working-directory: main/${{ env.INSTALL_DIR }}
         run: yarn install ${{ inputs.INSTALL_FLAGS }} ${{ inputs.SKIP_CLI_INSTALL == true && '--mode=skip-build' || '' }}
+
+      - name: Copy Required Dependencies to Workspace
+        if: inputs.SKIP_CLI_INSTALL == true
+        working-directory: main/${{ env.INSTALL_DIR }}
+        run: |
+          requiredModules=(
+            "@twilio/flex-ui"
+            "react-dom"
+            "react"
+          )
+
+          for module in "${requiredModules[@]}"; do
+            mkdir -p "$PLUGIN_MODULES/$module"
+            cp "$ROOT_MODULES/$module/package.json" "$PLUGIN_MODULES/$module/package.json"
+          done
+        env:
+          ROOT_MODULES: main/${{ env.INSTALL_DIR }}/node_modules
+          PLUGIN_MODULES: main/${{ env.PLUGIN_DIR }}/node_modules
 
       - name: Build ${{ steps.pluginProperties.outputs.PLUGIN_NAME }}
         working-directory: main

--- a/.github/workflows/build-twilio-flex-plugin.yaml
+++ b/.github/workflows/build-twilio-flex-plugin.yaml
@@ -144,14 +144,8 @@ jobs:
           done
 
       - name: Build ${{ steps.pluginProperties.outputs.PLUGIN_NAME }}
-        working-directory: main
-        run: |
-          if [ -z "${{ inputs.BUILD_COMMAND_DIRECTORY }}" ]; then
-            cd ${{ env.INSTALL_DIR }}
-          else
-            cd ${{ inputs.BUILD_COMMAND_DIRECTORY }}
-          fi
-          ${{ inputs.BUILD_COMMAND }}
+        working-directory: main/${{ inputs.BUILD_COMMAND_DIRECTORY != '' && inputs.BUILD_COMMAND_DIRECTORY || env.INSTALL_DIR }}
+        run: ${{ inputs.BUILD_COMMAND }}
         env:
           TWILIO_ACCOUNT_SID: ACX # Dummy credentials for CLI. Not needed to build
           TWILIO_AUTH_TOKEN: X

--- a/.github/workflows/build-twilio-flex-plugin.yaml
+++ b/.github/workflows/build-twilio-flex-plugin.yaml
@@ -38,6 +38,15 @@ on:
         type: string
         required: false
         description: (Optional) Set if the .yarn directory is outside of the INSTALL_DIRECTORY
+      SKIP_CLI_INSTALL:
+        type: boolean
+        required: false
+        description: |
+          Set to `true` to skip the installation of Twilio CLI + Flex CLI.
+
+          This can be used if your plugin build command uses `flex-plugin build` directly instead of the CLI command `twilio flex:plugins:build`.
+
+          The install flags will have `--mode=skip-build` appended to them to avoid running the postinstall command that checks for the CLI installation.
         
 jobs:
   build_flex_plugin:
@@ -101,16 +110,25 @@ jobs:
           cache-dependency-path: ${{ env.CACHE_DEPENDENCY_PATH }}
 
       - name: Setup Flex CLI
+        if: ${{ inputs.SKIP_CLI_INSTALL != true }}
         uses: ./helpers/setup-flex-cli
-        id: flexCli
         with:
           PLUGIN_DIRECTORY: main/${{ env.PLUGIN_DIR }}
 
+      - name: Get Plugin Properties
+        id: pluginProperties
+        working-directory: main/${{ env.PLUGIN_DIR }}
+        run: |
+          PLUGIN_NAME=$(cat package.json | jq -r '.name')
+          echo "PLUGIN_NAME=$PLUGIN_NAME" >> $GITHUB_OUTPUT
+          PLUGIN_VERSION=$(cat package.json | jq -r '.version')
+          echo "PLUGIN_VERSION=$PLUGIN_VERSION" >> $GITHUB_OUTPUT
+
       - name: Install Dependencies
         working-directory: main/${{ env.INSTALL_DIR }}
-        run: yarn install ${{ inputs.INSTALL_FLAGS }}
+        run: yarn install ${{ inputs.INSTALL_FLAGS }} ${{ inputs.SKIP_CLI_INSTALL == true && '--mode=skip-build' || '' }}
 
-      - name: Build ${{ steps.flexCli.outputs.PLUGIN_NAME }}
+      - name: Build ${{ steps.pluginProperties.outputs.PLUGIN_NAME }}
         working-directory: main
         run: |
           if [ -z "${{ inputs.BUILD_COMMAND_DIRECTORY }}" ]; then
@@ -126,7 +144,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "${{ steps.flexCli.outputs.PLUGIN_NAME }}@${{ steps.flexCli.outputs.PLUGIN_VERSION }}"
+          name: "${{ steps.pluginProperties.outputs.PLUGIN_NAME }}@${{ steps.pluginProperties.outputs.PLUGIN_VERSION }}"
           path: main/${{ env.PLUGIN_DIR }}/build
           retention-days: ${{ inputs.ARTIFACT_RETENTION_PERIOD }}
           if-no-files-found: error

--- a/.github/workflows/build-twilio-flex-plugin.yaml
+++ b/.github/workflows/build-twilio-flex-plugin.yaml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Copy Required Dependencies to Workspace
         if: inputs.SKIP_CLI_INSTALL == true
-        working-directory: main/${{ env.INSTALL_DIR }}
+        working-directory: main
         run: |
           requiredModules=(
             "@twilio/flex-ui"
@@ -139,12 +139,9 @@ jobs:
           )
 
           for module in "${requiredModules[@]}"; do
-            mkdir -p "$PLUGIN_MODULES/$module"
-            cp "$ROOT_MODULES/$module/package.json" "$PLUGIN_MODULES/$module/package.json"
+            mkdir -p "${{ env.PLUGIN_DIR }}/node_modules/$module"
+            cp "${{ env.INSTALL_DIR }}/node_modules/$module/package.json" "${{ env.PLUGIN_DIR }}/node_modules/$module/package.json"
           done
-        env:
-          ROOT_MODULES: main/${{ env.INSTALL_DIR }}/node_modules
-          PLUGIN_MODULES: main/${{ env.PLUGIN_DIR }}/node_modules
 
       - name: Build ${{ steps.pluginProperties.outputs.PLUGIN_NAME }}
         working-directory: main

--- a/.github/workflows/test-twilio-flex-plugin.yaml
+++ b/.github/workflows/test-twilio-flex-plugin.yaml
@@ -78,14 +78,8 @@ jobs:
         run: yarn install ${{ inputs.INSTALL_FLAGS }}
 
       - name: Test ${{ steps.flexCli.outputs.PLUGIN_NAME }}
-        working-directory: main
-        run: |
-          if [ -z "${{ inputs.TEST_COMMAND_DIRECTORY }}" ]; then
-            cd ${{ inputs.INSTALL_DIRECTORY }}
-          else
-            cd ${{ inputs.TEST_COMMAND_DIRECTORY }}
-          fi
-          ${{ inputs.TEST_COMMAND }}
+        working-directory: main/${{ inputs.TEST_COMMAND_DIRECTORY != '' && inputs.TEST_COMMAND_DIRECTORY || inputs.INSTALL_DIRECTORY }}
+        run: ${{ inputs.TEST_COMMAND }}
         env:
           TWILIO_ACCOUNT_SID: ACX # Dummy credentials for CLI. Not needed to test
           TWILIO_AUTH_TOKEN: X

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This has been created as a **public** repository so that customer copies of your
     - [Get Twilio Resource Sid](docs/usage/composite-actions-general.md#get-twilio-resource-sid)
     - [Update Twilio Functions Variables](docs/usage/composite-actions-general.md#update-twilio-functions-variables)
     - [Update Flex Config](docs/usage/composite-actions-general.md#update-flex-config)
+    - [Update Flex Skills](docs/usage/composite-actions-general.md#update-flex-skills)
     - [Setup Flex CLI](docs/usage/composite-actions-general.md#setup-flex-cli)
     - [Deploy Flex Plugin Asset](docs/usage/composite-actions-general.md#deploy-flex-plugin-asset)
     - [Create Flex Plugin Version](docs/usage/composite-actions-general.md#create-flex-plugin-version)

--- a/docs/usage/composite-actions-general.md
+++ b/docs/usage/composite-actions-general.md
@@ -9,6 +9,9 @@
     - [Example 4: Flex Conversation Service](#example-4-flex-conversation-service)
   - [Update Twilio Functions Variables](#update-twilio-functions-variables)
   - [Update Flex Config](#update-flex-config)
+  - [Update Flex Skills](#update-flex-skills)
+    - [Simple Skills](#simple-skills)
+    - [Complex Skills](#complex-skills)
   - [Setup Flex CLI](#setup-flex-cli)
   - [Deploy Flex Plugin Asset](#deploy-flex-plugin-asset)
   - [Create Flex Plugin Version](#create-flex-plugin-version)
@@ -205,6 +208,49 @@ This will update the Flex Configuration accordingly:
     }
   }
 }
+```
+
+## [Update Flex Skills](../../update-flex-skills/action.yaml)
+
+Update Twilio Flex Agent Skills by updating the Flex Configuration object. By default it will merge with existing skills on the account, but you can set the **MODE** input variable to `replace`.
+
+### Simple Skills
+
+You can provide just a list of skill names (newline-separated).
+
+```yaml
+steps:
+
+  - name: Update Flex Skills
+    uses: zingdevlimited/actions-helpers/update-flex-skills@v3
+    with:
+      TWILIO_ACCOUNT_SID: ${{ env.TWILIO_ACCOUNT_SID }}
+      TWILIO_API_KEY: ${{ env.TWILIO_API_KEY }}
+      TWILIO_API_SECRET: ${{ env.TWILIO_API_SECRET }}
+      SIMPLE_SKILLS: |
+        sales
+        support
+        billing
+```
+
+### Complex Skills
+
+If you want skill levels you need to provide a JSON array.
+
+```yaml
+steps:
+
+  - name: Update Flex Skills
+    uses: zingdevlimited/actions-helpers/update-flex-skills@v3
+    with:
+      TWILIO_ACCOUNT_SID: ${{ env.TWILIO_ACCOUNT_SID }}
+      TWILIO_API_KEY: ${{ env.TWILIO_API_KEY }}
+      TWILIO_API_SECRET: ${{ env.TWILIO_API_SECRET }}
+      COMPLEX_SKILLS: |
+        [
+          {"name": "sales", "multivalue": true, "minimum": 1, "maximum": 5},
+          {"name": "billing", "multivalue": false, "minimum": null, "maximum": null}
+        ]
 ```
 
 ## [Setup Flex CLI](../../setup-flex-cli/action.yaml)

--- a/update-flex-skills/action.yaml
+++ b/update-flex-skills/action.yaml
@@ -1,0 +1,61 @@
+name: "Update Twilio Flex Worker Skills"
+description: Update the Twilio Flex Worker Skills Configuration
+inputs:
+  SIMPLE_SKILLS:
+    required: false
+    description: A newline separated list of Flex skills that do not have any levels
+  COMPLEX_SKILLS:
+    required: false
+    description: |
+      A JSON list of skill objects where you can define levels. The objects must be of the structure:
+
+      ```json
+      {
+        "name": "skillName",
+        "multivalue": false | true,
+        "minimum": null | number,
+        "maximum": null | number,
+      }
+      ```
+  MODE:
+    required: false
+    description: Set to `merge` or `replace`. Defaults to `merge`
+    default: merge
+  TWILIO_ACCOUNT_SID:
+    required: true
+    description: The Twilio Account SID
+  TWILIO_API_KEY:
+    required: true
+    description: Twilio API Key
+  TWILIO_API_SECRET:
+    required: true
+    description: Twilio API Secret
+
+runs:
+  using: composite
+  steps:
+    - name: Validate Inputs
+      shell: bash
+      run: |
+        fail=""
+        [[ -z "${{ inputs.TWILIO_ACCOUNT_SID }}" ]] && echo "::error::Missing TWILIO_ACCOUNT_SID in inputs" && fail=1
+        [[ -z "${{ inputs.TWILIO_API_KEY }}" ]] && echo "::error::Missing TWILIO_API_KEY in inputs" && fail=1
+        [[ -z "${{ inputs.TWILIO_API_SECRET }}" ]] && echo "::error::Missing TWILIO_API_SECRET in inputs" && fail=1
+
+        [[ -z "$SIMPLE_SKILLS" ]] && [[ -z "$COMPLEX_SKILLS" ]] && echo "::error::You need to specify either SIMPLE_SKILLS or COMPLEX_SKILLS in inputs" && fail=1
+
+        [[ -n "$fail" ]] && exit 1 || exit 0
+      env:
+        SIMPLE_SKILLS: ${{ inputs.SIMPLE_SKILLS }}
+        COMPLEX_SKILLS: ${{ inputs.COMPLEX_SKILLS }}
+
+    - name: Update Flex Skills (${{ inputs.TWILIO_ACCOUNT_SID }})
+      shell: bash
+      run: ${{ github.action_path }}/update-flex-skills.sh
+      env:
+        SIMPLE_SKILLS: ${{ inputs.SIMPLE_SKILLS }}
+        COMPLEX_SKILLS: ${{ inputs.COMPLEX_SKILLS }}
+        MODE: ${{ inputs.MODE }}
+        TWILIO_ACCOUNT_SID: ${{ inputs.TWILIO_ACCOUNT_SID }}
+        TWILIO_API_KEY: ${{ inputs.TWILIO_API_KEY }}
+        TWILIO_API_SECRET: ${{ inputs.TWILIO_API_SECRET }}

--- a/update-flex-skills/action.yaml
+++ b/update-flex-skills/action.yaml
@@ -1,5 +1,5 @@
 name: "Update Twilio Flex Worker Skills"
-description: Update the Twilio Flex Worker Skills Configuration
+description: Update the Twilio Flex Worker Skills Configuration [Documentation](https://github.com/zingdevlimited/actions-helpers/blob/v3/docs/usage/composite-actions-general.md#update-flex-skills)
 inputs:
   SIMPLE_SKILLS:
     required: false
@@ -7,7 +7,7 @@ inputs:
   COMPLEX_SKILLS:
     required: false
     description: |
-      A JSON list of skill objects where you can define levels. The objects must be of the structure:
+      A JSON array of skill objects where you can define levels. The objects must be of the structure:
 
       ```json
       {

--- a/update-flex-skills/update-flex-skills.sh
+++ b/update-flex-skills/update-flex-skills.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+response=$(curl -sX GET "https://flex-api.twilio.com/v1/Configuration"\
+  -u "$TWILIO_API_KEY:$TWILIO_API_SECRET") || exit 1
+
+if [ -z "$(echo "$response" | jq -r '.ui_attributes // empty')" ]
+then
+  echo "::error::Failed to retrieve Flex Configuration. Response: $response" >&2
+  exit 1
+fi
+
+skillsArray=$(echo "$response" | jq '.taskrouter_skills // empty')
+if [ -z "$skillsArray" ] || [ "$MODE" == "replace" ]; then
+  skillsArray="[]"
+fi
+
+if [ -n "$SIMPLE_SKILLS" ]; then
+  while IFS= read -r line && [[ -n $line ]]; do
+    skillName=$(echo "$line" | xargs) # Trim whitespace
+
+    if [ "$(echo "$skillsArray" | jq ". | any(.name == \"$skillName\") | not")" == "true" ]; then
+      obj="{
+        \"name\": \"$skillName\",
+        \"multivalue\": false,
+        \"minimum\": null,
+        \"maximum\": null
+      }"
+      skillsArray=$(echo "$skillsArray" | jq --argjson VAR "$obj" '. + [$VAR]')
+    fi
+  done <<< "$SIMPLE_SKILLS"
+fi
+if [ -n "$COMPLEX_SKILLS" ]; then
+  for skillEncoded in $(echo "$COMPLEX_SKILLS" | jq -r '.[] | @base64'); do
+    skill=$(echo "$skillEncoded" | base64 --decode)
+    skillName=$(echo "$skill" | jq -r '.name')
+    if [ "$(echo "$skillsArray" | jq ". | any(.name == \"$skillName\") | not")" == "true" ]; then
+      skillsArray=$(echo "$skillsArray" | jq --argjson VAR "$skill" '. + [$VAR]')
+    fi
+  done
+fi
+
+payload="{
+  \"account_sid\": \"$TWILIO_ACCOUNT_SID\",
+  \"taskrouter_skills\": $skillsArray
+}"
+payload=$(echo "$payload" | jq -c '')
+
+curl -sX POST https://flex-api.twilio.com/v1/Configuration \
+    -u "$TWILIO_API_KEY:$TWILIO_API_SECRET" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" || exit 1


### PR DESCRIPTION
## Build Twilio Flex Plugin Workflow

- Added opt-in input for SKIP_CLI_INSTALL for faster builds by skipping installation of Twilio and Flex CLI
- Added github ternary for working-directory instead of `cd` so path not found errors stop the workflow correctly

## New Action: Update Flex Skills

- Added merge mode and replace mode
- Added SIMPLE_SKILLS input and COMPLEX_SKILLS input
- Added entry in usage documentation