### PR TITLE
patch: Register Event Stream Webhook content type header check

### DIFF
--- a/register-event-stream-webhook/index.js
+++ b/register-event-stream-webhook/index.js
@@ -58,7 +58,7 @@ const asyncTwilioRequest = async (url, method, bodyParams = undefined, retryNumb
     }
 
     let responseBody;
-    if (req.headers.get("Content-Type") === "application/json" && req.status !== 204) {
+    if (req.headers.get("Content-Type")?.startsWith("application/json") && req.status !== 204) {
       responseBody = await req.json();
     } else {
       responseBody = {};


### PR DESCRIPTION
Twilio has started setting the content type header to `application/json;charset:utf-8`. This caused issues with the check to get the response body data.
