### PR TITLE
Patch: Update Deploy azure functions Reusable workflow

### DIFF
--- a/.github/workflows/deploy-azure-functions.yaml
+++ b/.github/workflows/deploy-azure-functions.yaml
@@ -155,5 +155,4 @@ jobs:
           AZURE_FUNC_NAME: ${{ inputs.INSTANCE_NAME }}
 
       - name: Delete Zip file
-        working-directory: main
         run: rm dist.zip

--- a/azure/terraform-output/action.yaml
+++ b/azure/terraform-output/action.yaml
@@ -66,7 +66,7 @@ runs:
 
     - name: Azure Login
       if: inputs.SKIP_AZURE_LOGIN != 'true'
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         client-id: ${{ inputs.AZ_CLIENT_ID }}
         tenant-id: ${{ inputs.AZ_TENANT_ID }}


### PR DESCRIPTION
Due to Azure CLI changes this workflow stopped working. Azure CLI version has now been fixed to a specific version