### PR TITLE
patch: jq ubuntu-24.04 support

### DIFF
--- a/.github/workflows/deploy-twilio-functions.yaml
+++ b/.github/workflows/deploy-twilio-functions.yaml
@@ -154,7 +154,7 @@ jobs:
       run: |
           mkdir -p src/functions
           deployOutput=$(npx twilio-run@3.5.3 deploy --production \
-            --username $TWILIO_API_KEY --password $TWILIO_API_SECRET --output-format json | jq '')
+            --username $TWILIO_API_KEY --password $TWILIO_API_SECRET --output-format json | jq '.')
           if [ "$?" != "0" ] || [ -z "$(echo "$deployOutput" | jq -r '.serviceSid // empty')" ]; then
             echo "::error::Functions deployment has failed. Please check the run logs." >&2
             echo "$deployOutput" >&2

--- a/update-flex-config/update-flex-config.sh
+++ b/update-flex-config/update-flex-config.sh
@@ -64,9 +64,9 @@ if [ -z "$(echo "$updateResponse" | jq -r '.ui_attributes // empty')" ]; then
 fi
 
 echo "Updated Flex Configuration .ui_attributes.$configSection:" >&2
-echo "$mergedConfig" | jq '' >&2
+echo "$mergedConfig" | jq '.' >&2
 
-displayConfig=$(echo "{\"$configSection\": $configDataJson}" | jq '')
+displayConfig=$(echo "{\"$configSection\": $configDataJson}" | jq '.')
 echo "## Updated Flex Configuration" >> "$GITHUB_STEP_SUMMARY"
 echo '```json' >> "$GITHUB_STEP_SUMMARY"
 echo "$displayConfig" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
There was an update to the `jq` package in ubuntu-24.04 where `jq ''` started throwing errors and has to be replaced with `jq '.'`