### PR TITLE
patch: Test Flex Plugin to select correct Node version

### DIFF
--- a/.github/workflows/test-twilio-flex-plugin.yaml
+++ b/.github/workflows/test-twilio-flex-plugin.yaml
@@ -32,12 +32,15 @@ on:
       NODE_VERSION:
         type: string
         required: false
-        description: (Optional) Override Node Version (Default 18)
-        default: 18.x
+        description: (Optional) Override Node Version (Default to engines.node or 18 if not found)
 
 jobs:
   plugin_test:
     runs-on: ubuntu-22.04
+    env:
+      PLUGIN_DIR: ${{ inputs.PLUGIN_DIRECTORY != '' && inputs.PLUGIN_DIRECTORY || '.' }}
+      INSTALL_DIR: ${{ inputs.INSTALL_DIRECTORY != '' && inputs.INSTALL_DIRECTORY || '.' }}
+      NODE_VERSION: ${{ inputs.NODE_VERSION }}
 
     steps:
       - name: Checkout ${{ github.repository }}@${{ github.ref_name }}
@@ -52,13 +55,24 @@ jobs:
           path: helpers
           ref: v3
 
-      - name: Resolve Cache Dependency Path
+      - name: Resolve Dependencies
         run: |
-          if [ "${{ inputs.INSTALL_DIRECTORY }}" == "." ]; then
+          if [ "${{ env.INSTALL_DIR }}" == "." ]; then
             echo "CACHE_DEPENDENCY_PATH=main/yarn.lock" >> "$GITHUB_ENV"
           else
-            echo "CACHE_DEPENDENCY_PATH=main/${{ inputs.INSTALL_DIRECTORY }}/yarn.lock" >> "$GITHUB_ENV"
+            echo "CACHE_DEPENDENCY_PATH=main/${{ env.INSTALL_DIR }}/yarn.lock" >> "$GITHUB_ENV"
           fi
+
+          if [ -z "${{ inputs.NODE_VERSION }}" ]; then
+            nodeVer=$(cat main/${{ env.PLUGIN_DIR }}/package.json | jq -r '.engines.node // empty')
+            if [ -z "$nodeVer" ]; then
+              nodeVer=$(cat main/${{ env.INSTALL_DIR }}/package.json | jq -r '.engines.node // empty')
+            fi
+            if [ -z "$nodeVer" ]; then
+              nodeVer="18.x"
+            fi
+          fi
+          echo "NODE_VERSION=$nodeVer" >> "$GITHUB_ENV"
 
       - name: Set up Node ${{ inputs.NODE_VERSION }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
Test Flex Plugin should do the same as Build Flex Plugin and check the `engines.node` field to auto-select the correct Node version if available.