### PR TITLE
Allow "deploy assets" helper to preserve existing files

### DIFF
--- a/deploy-assets/README.md
+++ b/deploy-assets/README.md
@@ -6,7 +6,7 @@ By default, deployments to the provided environment are overwritten so only the 
 
 Set `PRESERVE_EXISTING: true` to keep currently deployed assets that are not included in the `ASSETS_DIRECTORY` on the Functions Service.
 
-If an `ENVIRONMENT_NAME` and `ENVIRONMENT_SUFFIX` is not specified, then the assets will be deployed to the production Environment of the Service.
+If an `ENVIRONMENT_NAME` and `ENVIRONMENT_SUFFIX` are not specified, then the assets will be deployed to the production Environment of the Service.
 
 ```yaml
 steps:

--- a/deploy-assets/README.md
+++ b/deploy-assets/README.md
@@ -1,17 +1,19 @@
 # Deploy Assets
 
-Deploy Assets to a Twilio Serverless Service. All required resources (Service, Environment, Asset) will be created if they do not exist. By default, deployments to the provided environment are overwritten so only the assets explicitly specified will be active.
+Deploy Assets to a Twilio Serverless Service. All required resources (Service, Environment, Asset) will be created if they do not exist. 
 
-Set `PRESERVE_EXISTING: true` to keep currently deployed assets that are not included in `ASSETS_DIRECTORY`.
+By default, deployments to the provided environment are overwritten so only the assets explicitly provided in the assets directory will be active (this can be changed by setting the `PRESERVE_EXISTING` parameter flag).
 
-If an `ENVIRONMENT_NAME` and `ENVIRONMENT_SUFFIX` is not specified then the assets will be deployed to the production Environment of the Service.
+Set `PRESERVE_EXISTING: true` to keep currently deployed assets that are not included in the `ASSETS_DIRECTORY` on the Functions Service.
+
+If an `ENVIRONMENT_NAME` and `ENVIRONMENT_SUFFIX` is not specified, then the assets will be deployed to the production Environment of the Service.
 
 ```yaml
 steps:
   (...)
 
   - name: Deploy Assets
-    uses: zingdevlimited/actions-helpers/deploy-assets@v4
+    uses: zingdevlimited/actions-helpers/deploy-assets@v5
     with:
       ASSETS_DIRECTORY: assets/english
       SERVICE_NAME: example-studio-assets
@@ -43,7 +45,7 @@ steps:
   (...)
 
   - name: Deploy Assets
-    uses: zingdevlimited/actions-helpers/deploy-assets@v4
+    uses: zingdevlimited/actions-helpers/deploy-assets@v5
     with:
       ASSETS_DIRECTORY: assets/english
       SERVICE_NAME: example-studio-assets

--- a/deploy-assets/README.md
+++ b/deploy-assets/README.md
@@ -1,6 +1,8 @@
 # Deploy Assets
 
-Deploy Assets to a Twilio Serverless Service. All required resources (Service, Environment, Asset) will be created if they do not exist. Any deployments to the provided environment will be overwritten so only the assets explicitly specified will be active.
+Deploy Assets to a Twilio Serverless Service. All required resources (Service, Environment, Asset) will be created if they do not exist. By default, deployments to the provided environment are overwritten so only the assets explicitly specified will be active.
+
+Set `PRESERVE_EXISTING: true` to keep currently deployed assets that are not included in `ASSETS_DIRECTORY`.
 
 If an `ENVIRONMENT_NAME` and `ENVIRONMENT_SUFFIX` is not specified then the assets will be deployed to the production Environment of the Service.
 
@@ -16,6 +18,7 @@ steps:
       ENVIRONMENT_NAME: english
       ENVIRONMENT_SUFFIX: en
       UI_EDITABLE: false
+      PRESERVE_EXISTING: true
       TWILIO_API_KEY: ${{ env.TWILIO_API_KEY }}
       TWILIO_API_SECRET: ${{ env.TWILIO_API_SECRET }}
 ```

--- a/deploy-assets/action.yaml
+++ b/deploy-assets/action.yaml
@@ -36,6 +36,9 @@ inputs:
   UI_EDITABLE:
     required: false
     description: (Optional) Set to `true` to make the service editable through the Twilio Console UI
+  PRESERVE_EXISTING:
+    required: false
+    description: (Optional) Set to `true` to preserve existing deployed assets that are not being updated
 
 runs:
   using: node24

--- a/deploy-assets/index.mjs
+++ b/deploy-assets/index.mjs
@@ -159,7 +159,7 @@ if (INPUT_REPLACE_MARKERS_IN_EXT?.trim()) {
   markerEnabledFileExt = INPUT_REPLACE_MARKERS_IN_EXT.replaceAll(".", "").toLowerCase().split(",");
 }
 
-const preserveExisting = INPUT_PRESERVE_EXISTING === "true";
+const preserveExisting = INPUT_PRESERVE_EXISTING?.toLowerCase() === "true";
 
 const assetFileList = /** @type {string[]} */ (
   readdirSync(INPUT_ASSETS_DIRECTORY, { recursive: true, withFileTypes: true })

--- a/deploy-assets/index.mjs
+++ b/deploy-assets/index.mjs
@@ -15,6 +15,7 @@ const {
   INPUT_ASSETS_DIRECTORY,
   INPUT_REPLACE_MARKERS_IN_EXT,
   INPUT_UI_EDITABLE,
+  INPUT_PRESERVE_EXISTING,
   GITHUB_STEP_SUMMARY,
 } = process.env;
 
@@ -158,6 +159,8 @@ if (INPUT_REPLACE_MARKERS_IN_EXT?.trim()) {
   markerEnabledFileExt = INPUT_REPLACE_MARKERS_IN_EXT.replaceAll(".", "").toLowerCase().split(",");
 }
 
+const preserveExisting = INPUT_PRESERVE_EXISTING === "true";
+
 const assetFileList = /** @type {string[]} */ (
   readdirSync(INPUT_ASSETS_DIRECTORY, { recursive: true, withFileTypes: true })
     .filter((dirent) => dirent.isFile())
@@ -253,6 +256,18 @@ const listAssetsResp = await asyncTwilioRequest(
 const assetList = listAssetsResp.body.assets;
 
 const assetsToUpdate = [];
+const assetPathsToUpdate = new Set();
+
+/** @param {string | undefined} assetPath */
+const normalizeAssetPath = (assetPath) => {
+  if (!assetPath) {
+    return "/";
+  }
+  const pathWithLeadingSlash = assetPath.startsWith("/")
+    ? assetPath
+    : `/${assetPath}`;
+  return pathWithLeadingSlash.replace(/\/{2,}/g, "/");
+};
 
 for (const assetFile of assetFileList) {
   const content = readFileSync(`${INPUT_ASSETS_DIRECTORY}/${assetFile}`);
@@ -266,6 +281,8 @@ for (const assetFile of assetFileList) {
     visibility = "protected";
     assetPath = assetPath.replace(".protected", "");
   }
+
+  assetPathsToUpdate.add(normalizeAssetPath(assetPath));
 
   const existing = assetList.find((a) => a.friendly_name === assetPath);
   if (existing) {
@@ -304,6 +321,37 @@ if (GITHUB_STEP_SUMMARY) {
 }
 
 const buildParams = new URLSearchParams();
+
+if (preserveExisting) {
+  const currentBuildSid = environment.build_sid;
+  if (currentBuildSid) {
+    const buildResp = await asyncTwilioRequest(
+      `${serverlessBaseUrl}/${serviceSid}/Builds/${currentBuildSid}`,
+      "GET"
+    );
+
+    /** @type {any[]} */
+    const buildAssetVersions = buildResp.body.asset_versions || [];
+    const preservedAssetVersions = buildAssetVersions
+      .filter((assetVersion) => {
+        const currentPath = normalizeAssetPath(assetVersion.path);
+        return !assetPathsToUpdate.has(currentPath);
+      })
+      .map((assetVersion) => assetVersion.sid);
+
+    for (const assetVersionSid of preservedAssetVersions) {
+      buildParams.append("AssetVersions", assetVersionSid);
+    }
+
+    console.log(
+      `Preserving ${preservedAssetVersions.length} existing asset versions from build ${currentBuildSid}.`
+    );
+  } else {
+    console.log(
+      "PRESERVE_EXISTING is true but there is no existing build on this environment."
+    );
+  }
+}
 
 for (const asset of assetsToUpdate) {
   const ext = asset.name.split(".").at(-1);


### PR DESCRIPTION
Add `PRESERVE_EXISTING` flag to the "Deploy Assets" action helper to allow for the existing assets in the Function Service to be retained when a new subset of assets is deployed.