### PR TITLE
Use default environment if no suffix is provided when getting functions service

### DIFF
--- a/get-twilio-functions-service/index.mjs
+++ b/get-twilio-functions-service/index.mjs
@@ -134,8 +134,10 @@ const environmentListResp = await asyncTwilioRequest(
 const environmentList = environmentListResp.body.environments;
 let environment;
 if (environmentSuffix === null) {
-  // Empty INPUT_ENVIRONMENT_SUFFIX resolves to the default environment (the one without a domain suffix)
-  environment = environmentList.find((e) => !e.domain_suffix);
+  // Empty INPUT_ENVIRONMENT_SUFFIX resolves to the default environment (the one without a domain suffix).
+  // If no unsuffixed environment exists, fall back to the first available environment.
+  // Note: this is to find Twilio Functions Services that are deployed as part of a Flex Library Plugin where Twilio uses a random suffix.
+  environment = environmentList.find((e) => !e.domain_suffix) || environmentList[0];
 } else {
   environment = environmentList.find(
     (e) => e.domain_suffix === environmentSuffix,
@@ -143,7 +145,7 @@ if (environmentSuffix === null) {
 }
 
 if (!environment && INPUT_IGNORE_NOT_FOUND !== "true") {
-  const environmentLookup = environmentSuffix === null ? "default environment (no suffix)" : `environment with suffix '${environmentSuffix}'`;
+  const environmentLookup = environmentSuffix === null ? "any environments" : `environment with suffix '${environmentSuffix}'`;
   console.error(
     `::error::Service ${resolvedServiceName} (${serviceSid}) does not have ${environmentLookup}`
   );

--- a/get-twilio-functions-service/index.mjs
+++ b/get-twilio-functions-service/index.mjs
@@ -145,10 +145,7 @@ if (environmentSuffix === null) {
 }
 
 if (!environment && INPUT_IGNORE_NOT_FOUND !== "true") {
-  const environmentLookup = environmentSuffix === null ? "any environments" : `environment with suffix '${environmentSuffix}'`;
-  console.error(
-    `::error::Service ${resolvedServiceName} (${serviceSid}) does not have ${environmentLookup}`
-  );
+  console.error(`::error::Service ${resolvedServiceName} (${serviceSid}) does not have environment with suffix '${environmentSuffix}'`);
   process.exit(1);
 }
 

--- a/get-twilio-functions-service/index.mjs
+++ b/get-twilio-functions-service/index.mjs
@@ -143,8 +143,9 @@ if (environmentSuffix === null) {
 }
 
 if (!environment && INPUT_IGNORE_NOT_FOUND !== "true") {
+  const environmentLookup = environmentSuffix === null ? "default environment (no suffix)" : `environment with suffix '${environmentSuffix}'`;
   console.error(
-    `::error::Service ${resolvedServiceName} (${serviceSid}) does not have Environment with suffix ${environmentSuffix}`,
+    `::error::Service ${resolvedServiceName} (${serviceSid}) does not have ${environmentLookup}`
   );
   process.exit(1);
 }

--- a/get-twilio-functions-service/index.mjs
+++ b/get-twilio-functions-service/index.mjs
@@ -134,7 +134,8 @@ const environmentListResp = await asyncTwilioRequest(
 const environmentList = environmentListResp.body.environments;
 let environment;
 if (environmentSuffix === null) {
-  environment = environmentList[0];
+  // Empty INPUT_ENVIRONMENT_SUFFIX resolves to the default environment (the one without a domain suffix)
+  environment = environmentList.find((e) => !e.domain_suffix);
 } else {
   environment = environmentList.find(
     (e) => e.domain_suffix === environmentSuffix,


### PR DESCRIPTION
Fix issue where the first environment was being selected when no suffix was provided. Instead, the default environment should be selected.